### PR TITLE
Api definition extensions

### DIFF
--- a/blocks/swaggerui/swaggerui.css
+++ b/blocks/swaggerui/swaggerui.css
@@ -2,6 +2,10 @@ raqn-swaggerui .topbar {
   display: none;
 }
 
+raqn-swaggerui .swagger-ui-selection.hidden{
+  display: none;
+}
+
 raqn-swaggerui .swagger-ui-selection ul input {
   transition: opacity 0.5s ease;
   margin: auto 10px;

--- a/blocks/swaggerui/swaggerui.css
+++ b/blocks/swaggerui/swaggerui.css
@@ -1,3 +1,22 @@
 raqn-swaggerui .topbar {
   display: none;
 }
+
+raqn-swaggerui .swagger-ui-selection ul input {
+  transition: opacity 0.5s ease;
+  margin: auto 10px;
+}
+
+raqn-swaggerui .swagger-ui-selection ul li.closed input {
+  opacity: 0;
+}
+
+raqn-swaggerui .swagger-ui-selection ul ul {
+  height: 300px;
+  overflow-y: scroll;
+  transition: height 0.5s ease-out, opacity 0.5s ease-out;
+}
+
+raqn-swaggerui .swagger-ui-selection ul li.closed ul {
+  height: 0;
+}

--- a/blocks/swaggerui/swaggerui.css
+++ b/blocks/swaggerui/swaggerui.css
@@ -2,10 +2,6 @@ raqn-swaggerui .topbar {
   display: none;
 }
 
-raqn-swaggerui .swagger-ui-selection.hidden{
-  display: none;
-}
-
 raqn-swaggerui .swagger-ui-selection ul input {
   transition: opacity 0.5s ease;
   margin: auto 10px;
@@ -16,9 +12,9 @@ raqn-swaggerui .swagger-ui-selection ul li.closed input {
 }
 
 raqn-swaggerui .swagger-ui-selection ul ul {
-  height: 300px;
+  max-height: 300px;
   overflow-y: scroll;
-  transition: height 0.5s ease-out, opacity 0.5s ease-out;
+  transition: max-height 0.5s ease-out, opacity 0.5s ease-out;
 }
 
 raqn-swaggerui .swagger-ui-selection ul li.closed ul {

--- a/blocks/swaggerui/swaggerui.js
+++ b/blocks/swaggerui/swaggerui.js
@@ -4,55 +4,92 @@ const prefixPath = '/api-definitions';
 
 export default class SwaggerUI extends ComponentBase {
 
-  async loadEnvironments() {
-    const response = await fetch(`${prefixPath}/environments.json`);
-    return response.json();
+  switchAPI(hash) {
+    const currentEnvironment = hash.length > 0 ? window.location.hash.substring(1).replace(/--.+$/, '') : false;
+    this.querySelectorAll('.swagger-ui-selection > ul > li').forEach((item) => {
+      if(item.dataset.environment === currentEnvironment) {
+        item.classList.remove('closed');
+      } else {
+        item.classList.add('closed');
+      }
+    });
+    const currentAPI = currentEnvironment && (() => {
+      const index = hash.indexOf('--');
+      return index !== -1 ? hash.substring(index + 2) : false;
+    })();
+    
+    const wrapperElement = this.querySelector('.swagger-ui-wrapper');
+    wrapperElement.innerHTML = '';
+    if(currentAPI) {
+      window.SwaggerUIBundle({
+        url: `${prefixPath}/${currentEnvironment}/${currentAPI}.yaml`,
+        domNode: wrapperElement,
+        presets: [window.SwaggerUIBundle.presets.apis, window.SwaggerUIStandalonePreset],
+        layout: 'StandaloneLayout',
+      });
+    }
+  }
+
+  navigationClick(e, hash) {
+    e.preventDefault();
+    if(!window.location.hash.startsWith(hash)) {
+      window.location.hash = hash;
+      this.switchAPI(hash);
+    }
   }
 
   async loadAPIs() {
-    const environmentsElement = this.querySelector('.swagger-ui-selection .environments');
-    const definitionsElement = this.querySelector('.swagger-ui-selection .definitions');
-    const wrapperElement = this.querySelector('.swagger-ui-wrapper');
-
-    const environments = await this.loadEnvironments();
-    environments.forEach((environment) => {
-      const option = document.createElement('option');
-      option.value = environment;
-      option.textContent = environment;
-      environmentsElement.appendChild(option);
-    });
-
-    environmentsElement.addEventListener('change', async () => {
-      const response = await fetch(`${prefixPath}/${environmentsElement.value}/index.json`);
-      const apis = await response.json();
-      definitionsElement.innerHTML = '';
-      wrapperElement.innerHTML = '';
-      apis.forEach((api) => {
-        const option = document.createElement('option');
-        option.value = api;
-        option.textContent = api;
-        definitionsElement.appendChild(option);
+    const response = await fetch(`${prefixPath}/environments.json`);
+    const environments = await response.json();
+    const environmentElements = await Promise.all(environments.map(async (environment) => {
+      const item = document.createElement('li');
+      item.dataset.environment = environment.folder;
+      const anchor = document.createElement('a');
+      const url = new URL(window.location.href);
+      url.hash = environment.folder;
+      anchor.addEventListener('click', (e) => this.navigationClick(e, url.hash));
+      anchor.href = url.toString();
+      anchor.textContent = environment.label;
+      item.appendChild(anchor);
+      const filter = document.createElement('input');
+      filter.placeholder = 'Search';
+      item.appendChild(filter);
+      const apiResponse = await fetch(`${prefixPath}/${environment.folder}/index.json`);
+      const apis = await apiResponse.json();
+      const definitionsElement = document.createElement('ul');
+      apis.sort((a, b) => a.label.localeCompare(b.label)).forEach((api) => {
+        const apiItem = document.createElement('li');
+        const apiAnchor = document.createElement('a');
+        const apiUrl = new URL(window.location.href);
+        apiUrl.hash = `${environment.folder}--${api.id}`;
+        apiAnchor.addEventListener('click', (e) => this.navigationClick(e, apiUrl.hash));
+        apiAnchor.href = apiUrl.toString();
+        apiAnchor.textContent = `${api.label}${api.version ? ` (${api.version})` : ''}`;
+        apiItem.appendChild(apiAnchor);
+        definitionsElement.appendChild(apiItem);
       });
-      definitionsElement.addEventListener('change', () => {
-        const file = definitionsElement.value;
-        wrapperElement.innerHTML = '';
-        window.SwaggerUIBundle({
-          url: `${prefixPath}/${environmentsElement.value}/${file}`,
-          domNode: wrapperElement,
-          presets: [window.SwaggerUIBundle.presets.apis, window.SwaggerUIStandalonePreset],
-          layout: 'StandaloneLayout',
+      item.appendChild(definitionsElement);
+      filter.addEventListener('input', () => {
+        definitionsElement.querySelectorAll('li').forEach((apiItem) => {
+          if (apiItem.textContent.toLowerCase().includes(filter.value.toLowerCase())) {
+            apiItem.style.display = 'block';
+          } else {
+            apiItem.style.display = 'none';
+          }
         });
       });
-      definitionsElement.dispatchEvent(new Event('change'));
-    });
-    environmentsElement.dispatchEvent(new Event('change'));
+      return item;
+    }));
+    const environmentsElement = this.querySelector('.swagger-ui-selection > ul');
+    environmentElements.forEach((option) => environmentsElement.appendChild(option));
+
+    this.switchAPI(window.location.hash);
   }
 
   async ready() {
     this.innerHTML = `
       <div class="swagger-ui-selection">
-        <select class="environments"></select>
-        <select class="definitions"></select>
+        <ul></ul>
       </div>
       <div class="swagger-ui-wrapper"></div>`;
     

--- a/blocks/swaggerui/swaggerui.js
+++ b/blocks/swaggerui/swaggerui.js
@@ -38,11 +38,7 @@ export default class SwaggerUI extends ComponentBase {
     }
   }
 
-  async loadAPIs(apiFilter) {
-    const selectionElement = this.querySelector('.swagger-ui-selection');
-    if(apiFilter.length > 0) {
-      selectionElement.classList.add('hidden');
-    }
+  async generateAPISelection(selectionElement) {
     const response = await fetch(`${prefixPath}/environments.json`);
     const environments = await response.json();
     const environmentElements = await Promise.all(environments.map(async (environment) => {
@@ -86,6 +82,13 @@ export default class SwaggerUI extends ComponentBase {
     }));
     const environmentsElement = selectionElement.querySelector(':scope > ul');
     environmentElements.forEach((option) => environmentsElement.appendChild(option));
+  }
+
+  async loadAPIs(apiFilter) {
+    const selectionElement = this.querySelector('.swagger-ui-selection');
+    if(apiFilter.length === 0) {
+      await this.generateAPISelection(selectionElement);
+    }
 
     const hashes = apiFilter.length > 0 ? apiFilter : [window.location.hash];
     hashes.forEach((hash) => {


### PR DESCRIPTION
Chaning API navigation to list instead of dropdown and adding feature to select specific APIs via SwaggerUI block definition.

Test URLs:
- Before: https://main--raqn-docs-sharepoint--henkel.aem.live/drafts/ahaller/swagger-ui
- After: https://api-definition-extensions--raqn-docs-sharepoint--henkel.aem.live/drafts/ahaller/swagger-ui (unfortunately works only on docs.raqn.io or locally with some tweaks)
